### PR TITLE
Add deployment script for registration app

### DIFF
--- a/Docs/infrastructure.md
+++ b/Docs/infrastructure.md
@@ -65,6 +65,24 @@ sudo systemctl restart n8n
 
 - Description: Updates n8n every 2 days and restarts service
 
+## 🚀 Registration Form Deployment
+
+- Repository cloned at `~/gtc-form`
+- Static site for the registration form is served from `/var/www/gtc-form`
+- Deployment is handled by the `deploy.sh` script committed in the repository root
+  - Installs dependencies with `npm ci`
+  - Stages the `Client/gtc-form` and `assets` directories
+  - Syncs the bundle into `/var/www/gtc-form` using `rsync --delete`
+- Run on GTC1 after pulling the latest changes:
+
+  ```bash
+  cd ~/gtc-form
+  git pull origin main
+  ./deploy.sh
+  ```
+
+- Script exits with non-zero codes when requirements are missing (npm/node/rsync) or if syncing fails, enabling monitoring by GitHub Actions
+
 ## 📦 Backup & Restore
 
 - Backup created with:

--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ Each application is located under `Apps/`:
 - `Apps/telegram-bot/`: messenger automation and AI interaction
 - `Apps/data-enrichment/`: catalog normalization and product hashing
 - `Apps/ui-dashboard/`: future visual interface for managing system
+
+## 🚀 Deployment
+
+The registration form is deployed to `/var/www/gtc-form` on the GTC1 server. Use the `deploy.sh` helper script from the repository root to build and sync the static assets:
+
+```bash
+ssh -i ~/.ssh/GTC1_key.pem kfilipenko@agent.gtstor.com
+cd ~/gtc-form
+git pull origin main
+./deploy.sh
+```
+
+The script installs Node dependencies with `npm ci`, stages the contents of `Client/gtc-form` and `assets`, and then uses `rsync` to update the server directory. Deployment is idempotent—rerunning the script safely refreshes the production files. Set the `DEPLOY_TARGET_DIR` environment variable if you need to test against an alternate path before updating production.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGING_ROOT="$PROJECT_ROOT/.deploy"
+BUILD_DIR="$STAGING_ROOT/build"
+NPM_WORK_DIR="$STAGING_ROOT/npm"
+TARGET_DIR="${DEPLOY_TARGET_DIR:-/var/www/gtc-form}"
+CLIENT_DIR="$PROJECT_ROOT/Client/gtc-form"
+ASSETS_DIR="$PROJECT_ROOT/assets"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+cleanup() {
+  if [ -d "$STAGING_ROOT" ]; then
+    rm -rf "$STAGING_ROOT"
+  fi
+}
+
+fail() {
+  local exit_code="$1"
+  shift
+  log "ERROR: $*"
+  exit "$exit_code"
+}
+
+trap cleanup EXIT
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail 10 "Required command '$cmd' is not available in PATH"
+  fi
+}
+
+log "Starting deployment from $PROJECT_ROOT"
+
+if [ ! -d "$CLIENT_DIR" ]; then
+  fail 11 "Client application directory not found at $CLIENT_DIR"
+fi
+
+require_command npm
+require_command node
+require_command rsync
+
+cd "$PROJECT_ROOT"
+
+log "Installing npm dependencies"
+rm -rf "$NPM_WORK_DIR"
+mkdir -p "$NPM_WORK_DIR"
+cp "$PROJECT_ROOT/package.json" "$PROJECT_ROOT/package-lock.json" "$NPM_WORK_DIR"/
+if ! npm ci --no-audit --no-fund --prefix "$NPM_WORK_DIR" >/dev/null; then
+  fail 20 "npm dependency installation failed"
+fi
+
+log "Staging static assets"
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+if ! rsync -a --delete "$CLIENT_DIR"/ "$BUILD_DIR"/; then
+  fail 30 "Failed to copy client application files"
+fi
+
+if [ -d "$ASSETS_DIR" ]; then
+  mkdir -p "$BUILD_DIR/assets"
+  if ! rsync -a --delete "$ASSETS_DIR"/ "$BUILD_DIR/assets"/; then
+    fail 31 "Failed to copy shared asset files"
+  fi
+fi
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  elif [ -w "$TARGET_DIR" ]; then
+    SUDO=""
+  else
+    fail 12 "Root privileges are required to write to $TARGET_DIR and sudo is not available"
+  fi
+fi
+
+run_target_cmd() {
+  if [ -n "$SUDO" ]; then
+    "$SUDO" "$@"
+  else
+    "$@"
+  fi
+}
+
+log "Syncing bundle to $TARGET_DIR"
+if ! run_target_cmd mkdir -p "$TARGET_DIR"; then
+  fail 40 "Failed to create target directory $TARGET_DIR"
+fi
+
+if ! run_target_cmd rsync -a --delete "$BUILD_DIR"/ "$TARGET_DIR"/; then
+  fail 41 "Failed to sync staged files to $TARGET_DIR"
+fi
+
+log "Deployment completed successfully"
+exit 0


### PR DESCRIPTION
## Summary
- add a deploy.sh helper that stages the registration form and syncs it to /var/www/gtc-form with clear exit codes
- document the deployment process in the main README and infrastructure overview

## Testing
- DEPLOY_TARGET_DIR="$(pwd)/tmp-deploy" ./deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2be54b638832aaf7c0d565b37dbea