### PR TITLE
Adjust password validation logic for login

### DIFF
--- a/Client/gtc-form/index.html
+++ b/Client/gtc-form/index.html
@@ -140,9 +140,19 @@
       const isRegister = this.value === "register";
       nameField.style.display = isRegister ? "block" : "none";
       document.getElementById("executionMode").value = this.value;
+      passwordInput.setAttribute(
+        "autocomplete",
+        isRegister ? "new-password" : "current-password"
+      );
+      passwordInput.dispatchEvent(new Event("input"));
     });
 
     passwordInput.addEventListener("input", () => {
+      if (modeSelect.value !== "register") {
+        strengthDisplay.textContent = "";
+        strengthDisplay.className = "password-strength";
+        return;
+      }
       const value = passwordInput.value;
       if (!value) {
         strengthDisplay.textContent = "";
@@ -158,10 +168,17 @@
     form.addEventListener("submit", async function (e) {
       e.preventDefault();
 
+      const mode = modeSelect.value;
       const password = passwordInput.value;
-      if (!validatePassword(password)) {
+      const isPasswordValid =
+        mode === "register" ? validatePassword(password) : Boolean(password);
+
+      if (!isPasswordValid) {
         confirmation.style.display = "block";
-        confirmation.textContent = "❌ Password must be at least 8 characters and include letters, numbers, and special characters.";
+        confirmation.textContent =
+          mode === "register"
+            ? "❌ Password must be at least 8 characters and include letters, numbers, and special characters."
+            : "❌ Please enter your password to log in.";
         confirmation.className = "confirmation error";
         return;
       }
@@ -188,7 +205,10 @@
 
         form.style.display = "none";
         confirmation.style.display = "block";
-        confirmation.textContent = "✅ You submitted a registration form. Please check your email inbox.";
+        confirmation.textContent =
+          mode === "register"
+            ? "✅ You submitted a registration form. Please check your email inbox."
+            : "✅ Login successful. Welcome back!";
         confirmation.className = "confirmation success";
       } catch (err) {
         console.error("Form submission error:", err);

--- a/Docs/login-regression-test.md
+++ b/Docs/login-regression-test.md
@@ -1,0 +1,20 @@
+# Login Regression Test
+
+This manual regression test confirms that logins with existing passwords continue to work after the password validation changes.
+
+## Preconditions
+- An existing account that previously logged in successfully.
+- Access to the deployed GTC Unified Access form.
+
+## Steps
+1. Open the GTC Unified Access form in a browser.
+2. Ensure the **Select action** dropdown is set to **Login**.
+3. Enter the email address for the existing account.
+4. Type the known existing password (even if it does not meet the registration strength requirements).
+5. Submit the form by selecting **Continue**.
+
+## Expected Result
+- The form submits successfully without password strength errors.
+- A confirmation message appears that reads: `✅ Login successful. Welcome back!`
+
+If either condition fails, capture the behavior and report it as a regression.


### PR DESCRIPTION
## Summary
- gate password strength checks so they only apply when registering and keep login validation to a basic non-empty requirement
- tailor confirmation and error messaging to reflect whether the user is registering or logging in
- document a manual regression test to confirm legacy passwords can still log in successfully

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2be5dd5b0832aa7da716e66df3c97