### PR TITLE
Add Google Sign-In support to unified form

### DIFF
--- a/Client/gtc-form/index.html
+++ b/Client/gtc-form/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>GTC Unified Access</title>
   <link rel="icon" href="https://kfilipenko.github.io/gtc-form/assets/logo.png" type="image/png">
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <style>
     body {
       margin: 0;
@@ -79,6 +80,74 @@
       color: #29b6f6;
       font-weight: bold;
     }
+    .divider {
+      margin: 1.5rem 0 0.75rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #90a4ae;
+      font-size: 0.75rem;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+    }
+    .divider::before,
+    .divider::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: rgba(255, 255, 255, 0.15);
+      margin: 0 0.75rem;
+    }
+    input[readonly],
+    input:disabled {
+      background: #1b223d;
+      cursor: not-allowed;
+      color: #cfd8dc;
+    }
+    .google-section {
+      margin-top: 0.75rem;
+      padding-top: 0.75rem;
+    }
+    .google-intro {
+      margin-bottom: 0.75rem;
+      font-size: 0.95rem;
+      color: #cfd8dc;
+    }
+    .google-button {
+      display: flex;
+      justify-content: center;
+    }
+    .google-status {
+      margin-top: 0.75rem;
+      font-size: 0.9rem;
+      min-height: 1.2rem;
+      display: none;
+    }
+    .google-status.info,
+    .google-status.loading {
+      color: #29b6f6;
+    }
+    .google-status.success {
+      color: #8bc34a;
+    }
+    .google-status.error {
+      color: #ff5252;
+    }
+    .google-reset {
+      margin-top: 0.75rem;
+      padding: 0.45rem 1.1rem;
+      border-radius: 6px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      background: transparent;
+      color: #fff;
+      cursor: pointer;
+      transition: border-color 0.3s, background 0.3s;
+      display: none;
+    }
+    .google-reset:hover {
+      border-color: #fff;
+      background: rgba(255, 255, 255, 0.08);
+    }
   </style>
 </head>
 <body>
@@ -122,6 +191,13 @@
         <button type="submit">Continue</button>
       </form>
       <p class="confirmation" id="confirmation"></p>
+      <div class="divider" id="googleDivider" style="display:none;">or</div>
+      <section id="googleSection" class="google-section" style="display:none;">
+        <p class="google-intro">Register instantly with your Google account:</p>
+        <div id="googleSignInButton" class="google-button" role="presentation"></div>
+        <p id="googleStatus" class="google-status" role="status" aria-live="polite"></p>
+        <button type="button" id="googleReset" class="google-reset">Use a different Google account</button>
+      </section>
     </section>
   </main>
 
@@ -132,12 +208,78 @@
     const confirmation = document.getElementById("confirmation");
     const passwordInput = document.getElementById("password");
     const strengthDisplay = document.getElementById("passwordStrength");
+    const emailInput = document.getElementById("email");
+    const googleSubField = document.getElementById("googleSub");
+    const googleSection = document.getElementById("googleSection");
+    const googleDivider = document.getElementById("googleDivider");
+    const googleButtonContainer = document.getElementById("googleSignInButton");
+    const googleStatus = document.getElementById("googleStatus");
+    const googleResetButton = document.getElementById("googleReset");
 
     const API_ENDPOINTS = {
       emailRegistration: "https://app.gtstor.com/api/rpc/register_user_email",
       googleRegistration: "https://app.gtstor.com/api/rpc/register_user_google",
       legacyLogin: "https://kfilipenko.app.n8n.cloud/webhook/user-register",
     };
+
+    const GOOGLE_LIBRARY_RETRY_MS = 250;
+    const GOOGLE_LIBRARY_TIMEOUT_MS = 10000;
+
+    function normalizeToArray(value) {
+      if (!value) {
+        return [];
+      }
+      if (Array.isArray(value)) {
+        return value.map((item) => String(item).trim()).filter(Boolean);
+      }
+      if (typeof value === "string") {
+        return value
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean);
+      }
+      return [String(value).trim()].filter(Boolean);
+    }
+
+    const GOOGLE_CLIENT_IDS = (() => {
+      const candidates = [
+        window.GTC_FORM_GOOGLE_CLIENT_ID,
+        window.GTC_GOOGLE_CLIENT_ID,
+        window.GTC_FORM_GOOGLE_CLIENT_IDS,
+        window.GTC_GOOGLE_CLIENT_IDS,
+        googleButtonContainer && googleButtonContainer.dataset
+          ? googleButtonContainer.dataset.clientId
+          : "",
+      ];
+
+      const meta = document.querySelector('meta[name="google-signin-client_id"]');
+      if (meta && meta.content) {
+        candidates.push(meta.content);
+      }
+
+      return Array.from(
+        new Set(
+          candidates
+            .map((candidate) => normalizeToArray(candidate))
+            .flat()
+            .filter(Boolean)
+        )
+      );
+    })();
+
+    const GOOGLE_CLIENT_ID = GOOGLE_CLIENT_IDS.length ? GOOGLE_CLIENT_IDS[0] : "";
+
+    const GOOGLE_VERIFIER_URL = (() => {
+      const override =
+        window.GTC_FORM_GOOGLE_TOKEN_VERIFIER || window.GTC_GOOGLE_TOKEN_VERIFIER_URL;
+      if (override && typeof override === "string") {
+        return override.trim();
+      }
+      return "https://oauth2.googleapis.com/tokeninfo";
+    })();
+
+    let googleLibraryAttempts = 0;
+    let googleButtonInitialized = false;
 
     // Set to true only if the legacy webhook still requires the deprecated fields.
     const ENABLE_LEGACY_LOGIN_FIELDS = false;
@@ -167,17 +309,18 @@
       confirmation.className = `confirmation ${status}`;
     }
 
-    function showSuccessDetails({ mode, isGoogleRegistration, gtcUserId }) {
+    function showSuccessDetails({ mode, isGoogleRegistration, gtcUserId, email }) {
       confirmation.style.display = "block";
       confirmation.className = "confirmation success";
       confirmation.textContent = "";
 
+      const emailSuffix = email ? ` for ${email}` : "";
       const baseMessage =
         mode === "register"
           ? isGoogleRegistration
-            ? "✅ Google account linked. Please check your email inbox."
-            : "✅ You submitted a registration form. Please check your email inbox."
-          : "✅ Login successful. Welcome back!";
+            ? `✅ Google registration complete${emailSuffix}. Please check your email inbox.`
+            : `✅ Email registration submitted${emailSuffix}. Please check your email inbox.`
+          : `✅ Login successful${emailSuffix}. Welcome back!`;
 
       confirmation.append(baseMessage);
 
@@ -364,6 +507,7 @@
         isRegister ? "new-password" : "current-password"
       );
       passwordInput.dispatchEvent(new Event("input"));
+      updateGoogleSectionVisibility();
     });
 
     passwordInput.addEventListener("input", () => {
@@ -446,15 +590,12 @@
           mode,
           isGoogleRegistration,
           gtcUserId,
+          email,
         });
 
         form.style.display = "none";
         if (isGoogleRegistration) {
-          form.dataset.googleSub = "";
-          const googleSubField = document.getElementById("googleSub");
-          if (googleSubField) {
-            googleSubField.value = "";
-          }
+          clearGoogleRegistrationState({ clearStatus: false });
         }
       } catch (err) {
         console.error("Form submission error:", err);
@@ -471,6 +612,274 @@
     });
 
     modeSelect.dispatchEvent(new Event("change"));
+
+    function updateGoogleSectionVisibility() {
+      if (!googleSection || !googleDivider) {
+        return;
+      }
+      const isRegister = modeSelect.value === "register";
+      googleSection.style.display = isRegister ? "block" : "none";
+      googleDivider.style.display = isRegister ? "flex" : "none";
+
+      if (!isRegister) {
+        clearGoogleRegistrationState({ clearStatus: true });
+        return;
+      }
+
+      initializeGoogleSignInButton();
+    }
+
+    function setGoogleStatus(message, status) {
+      if (!googleStatus) {
+        return;
+      }
+      googleStatus.textContent = message || "";
+      googleStatus.className = `google-status${status ? ` ${status}` : ""}`;
+      googleStatus.style.display = message ? "block" : "none";
+    }
+
+    function parseBoolean(value) {
+      return value === true || value === "true" || value === 1 || value === "1";
+    }
+
+    function clearGoogleRegistrationState({ clearStatus } = { clearStatus: true }) {
+      if (form.dataset.googleSub) {
+        delete form.dataset.googleSub;
+      }
+      if (form.dataset.googleEmail) {
+        delete form.dataset.googleEmail;
+      }
+      if (googleSubField) {
+        googleSubField.value = "";
+      }
+      if (emailInput) {
+        emailInput.readOnly = false;
+        emailInput.classList.remove("readonly-input");
+        emailInput.removeAttribute("aria-readonly");
+      }
+      if (passwordInput) {
+        passwordInput.disabled = false;
+        passwordInput.classList.remove("disabled-input");
+        if (modeSelect.value === "register") {
+          passwordInput.setAttribute("autocomplete", "new-password");
+        } else {
+          passwordInput.setAttribute("autocomplete", "current-password");
+        }
+      }
+      if (googleResetButton) {
+        googleResetButton.style.display = "none";
+      }
+      if (clearStatus) {
+        setGoogleStatus("", "");
+      }
+      if (passwordInput) {
+        passwordInput.dispatchEvent(new Event("input"));
+      }
+    }
+
+    function applyGoogleRegistrationState({ googleSub, email, emailVerified }) {
+      if (!googleSub) {
+        throw new Error("Missing Google subject identifier.");
+      }
+      if (!email) {
+        throw new Error("Unable to determine your Google email address.");
+      }
+
+      if (modeSelect.value !== "register") {
+        modeSelect.value = "register";
+        modeSelect.dispatchEvent(new Event("change"));
+      }
+
+      form.dataset.googleSub = googleSub;
+      form.dataset.googleEmail = email;
+      if (googleSubField) {
+        googleSubField.value = googleSub;
+      }
+
+      if (emailInput) {
+        emailInput.value = email;
+        emailInput.readOnly = true;
+        emailInput.classList.add("readonly-input");
+        emailInput.setAttribute("aria-readonly", "true");
+      }
+
+      if (passwordInput) {
+        passwordInput.value = "";
+        passwordInput.disabled = true;
+        passwordInput.classList.add("disabled-input");
+      }
+
+      strengthDisplay.textContent = "";
+      strengthDisplay.className = "password-strength";
+
+      const successMessage = emailVerified
+        ? `Google account ${email} verified. You can submit the form without a password.`
+        : `Google account ${email} linked. Complete the form to continue.`;
+      setGoogleStatus(successMessage, "success");
+
+      if (googleResetButton) {
+        googleResetButton.style.display = "inline-block";
+      }
+    }
+
+    async function verifyGoogleCredential(idToken) {
+      if (!idToken) {
+        throw new Error("Missing Google credential.");
+      }
+
+      const baseUrl = GOOGLE_VERIFIER_URL;
+      const separator = baseUrl.includes("?") ? "&" : "?";
+      const verificationUrl = `${baseUrl}${separator}id_token=${encodeURIComponent(idToken)}`;
+
+      let response;
+      try {
+        response = await fetch(verificationUrl);
+      } catch (networkError) {
+        throw new Error(
+          networkError instanceof Error
+            ? `Unable to reach Google for verification: ${networkError.message}`
+            : "Unable to reach Google for verification."
+        );
+      }
+
+      if (!response.ok) {
+        let detail = "";
+        try {
+          detail = await response.text();
+        } catch (readError) {
+          detail = "";
+        }
+        const suffix = detail ? ` ${detail}` : "";
+        throw new Error(`Google verification failed (${response.status}).${suffix}`.trim());
+      }
+
+      let payload;
+      try {
+        payload = await response.json();
+      } catch (parseError) {
+        throw new Error("Google verification returned an unexpected response.");
+      }
+
+      const googleSub = payload.sub || payload.user_id || payload.google_sub;
+      const email = payload.email ? String(payload.email).trim().toLowerCase() : "";
+      const emailVerified = parseBoolean(payload.email_verified);
+      const audience = payload.aud || payload.client_id;
+
+      if (!googleSub) {
+        throw new Error("Google verification response did not include a user identifier.");
+      }
+
+      if (!email) {
+        throw new Error("Google verification response did not include an email address.");
+      }
+
+      if (!emailVerified) {
+        throw new Error(
+          "Google could not confirm that your account email is verified. Please verify your Google email and try again."
+        );
+      }
+
+      if (GOOGLE_CLIENT_IDS.length && audience && !GOOGLE_CLIENT_IDS.includes(audience)) {
+        throw new Error(
+          "Google credential does not match the configured application. Please use the button on this page to try again."
+        );
+      }
+
+      return {
+        googleSub,
+        email,
+        emailVerified,
+      };
+    }
+
+    async function handleGoogleCredentialResponse(response) {
+      clearGoogleRegistrationState({ clearStatus: false });
+
+      if (!response || !response.credential) {
+        setGoogleStatus("Google sign-in did not return a credential. Please try again.", "error");
+        return;
+      }
+
+      setGoogleStatus("Verifying Google sign-in…", "loading");
+
+      try {
+        const verification = await verifyGoogleCredential(response.credential);
+        applyGoogleRegistrationState(verification);
+      } catch (error) {
+        console.error("Google verification error", error);
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Google sign-in failed. Please try again.";
+        clearGoogleRegistrationState({ clearStatus: false });
+        setGoogleStatus(message, "error");
+      }
+    }
+
+    function initializeGoogleSignInButton() {
+      if (!googleSection || !googleButtonContainer) {
+        return;
+      }
+
+      if (!GOOGLE_CLIENT_ID) {
+        setGoogleStatus(
+          "Google Sign-In is not configured for this environment. Please contact support or continue with email registration.",
+          "error"
+        );
+        return;
+      }
+
+      if (googleButtonInitialized) {
+        return;
+      }
+
+      if (!(window.google && window.google.accounts && window.google.accounts.id)) {
+        if (googleLibraryAttempts * GOOGLE_LIBRARY_RETRY_MS >= GOOGLE_LIBRARY_TIMEOUT_MS) {
+          setGoogleStatus(
+            "Google Sign-In could not be loaded. Please refresh the page or continue with email registration.",
+            "error"
+          );
+          return;
+        }
+        googleLibraryAttempts += 1;
+        setTimeout(initializeGoogleSignInButton, GOOGLE_LIBRARY_RETRY_MS);
+        return;
+      }
+
+      window.google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: handleGoogleCredentialResponse,
+        ux_mode: "popup",
+        auto_select: false,
+      });
+
+      window.google.accounts.id.renderButton(googleButtonContainer, {
+        theme: "outline",
+        size: "large",
+        width: "100%",
+        type: "standard",
+        shape: "rectangular",
+        text: "continue_with",
+      });
+
+      googleButtonInitialized = true;
+
+      if (!googleStatus.textContent) {
+        setGoogleStatus("Use the button above to verify your Google account.", "info");
+      }
+    }
+
+    if (googleResetButton) {
+      googleResetButton.addEventListener("click", () => {
+        clearGoogleRegistrationState({ clearStatus: true });
+        if (window.google && window.google.accounts && window.google.accounts.id) {
+          window.google.accounts.id.disableAutoSelect();
+        }
+        setGoogleStatus("Choose another Google account or continue with email registration.", "info");
+      });
+    }
+
+    window.handleGoogleCredentialResponse = handleGoogleCredentialResponse;
 
     const params = new URLSearchParams(window.location.search);
     if (params.get("verified") === "true") {


### PR DESCRIPTION
## Summary
- add styling and layout to show a Google Sign-In option beside the existing email workflow
- load the Google Identity Services SDK, verify returned credentials, and forward the verified google_sub/email to the PostgREST RPC
- enhance success and error messaging so the UI reflects Google vs email registrations and handles OAuth failures gracefully

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2e441eba0832ab70954f5d46bc17a