### PR TITLE
Add server-side password validation

### DIFF
--- a/srv/gtc-auth/server.js
+++ b/srv/gtc-auth/server.js
@@ -19,6 +19,23 @@ import {
 import { sendVerificationEmail } from './mail.js';
 import { verifyGoogleCredential } from './google.js';
 
+const PASSWORD_POLICY = {
+  minLength: 8,
+  letter: /[A-Za-z]/,
+  digit: /\d/,
+  special: /[^A-Za-z0-9]/
+};
+
+function isPasswordStrong(password) {
+  const value = String(password);
+  return (
+    value.length >= PASSWORD_POLICY.minLength &&
+    PASSWORD_POLICY.letter.test(value) &&
+    PASSWORD_POLICY.digit.test(value) &&
+    PASSWORD_POLICY.special.test(value)
+  );
+}
+
 const app = express();
 
 app.use(helmet());
@@ -61,6 +78,10 @@ app.post('/auth/register', async (req, res) => {
   try {
     const exists = await getEmailRow(em);
     if (exists) return res.status(409).json({ code: 'email_taken' });
+
+    if (!isPasswordStrong(password)) {
+      return res.status(400).json({ code: 'weak_password' });
+    }
 
     const rounds = +process.env.BCRYPT_ROUNDS || 12;
     const hash = await bcrypt.hash(password, rounds);

--- a/var/www/gtc-form/auth/email/index.html
+++ b/var/www/gtc-form/auth/email/index.html
@@ -406,6 +406,8 @@
           showError(registerError, 'This email is already registered. Try signing in instead.');
           signinEmailEl.textContent = currentEmail;
           showView('signin');
+        } else if (error.status === 400 && error.body?.code === 'weak_password') {
+          showError(registerError, 'Password must be at least 8 characters and include letters, numbers, and a special character.');
         } else {
           showError(registerError, 'Registration failed. Please try again.');
         }


### PR DESCRIPTION
## Summary
- add password strength validation to the email registration endpoint before hashing
- return a dedicated weak_password error code when the provided password is too weak
- surface the weak_password error message in the email registration form so the UI stays in sync

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d98d40d0d8832abc2d8adda8e23124