### PR TITLE
Configure Google auth client from deployment config

### DIFF
--- a/Docs/infrastructure.md
+++ b/Docs/infrastructure.md
@@ -77,11 +77,13 @@ sudo systemctl restart n8n
 
   ```bash
   cd ~/gtc-form
+  export GOOGLE_CLIENT_ID="<google-oauth-client-id>"
   git pull origin main
   ./deploy.sh
   ```
 
 - Script exits with non-zero codes when requirements are missing (npm/node/rsync) or if syncing fails, enabling monitoring by GitHub Actions
+- `deploy.sh` writes `/var/www/gtc-form/gtc-config.js` during sync. The script serializes the value of `$GOOGLE_CLIENT_ID` into that file so the Google sign-in page can initialize the OAuth client at runtime. Keep the environment variable in your shell profile or deployment automation to make redeployments reproducible.
 
 ## 📦 Backup & Restore
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,6 +70,17 @@ if [ -d "$ASSETS_DIR" ]; then
   fi
 fi
 
+log "Writing runtime configuration"
+GOOGLE_CLIENT_ID_ESCAPED=$(node -e "process.stdout.write(JSON.stringify(process.env.GOOGLE_CLIENT_ID || ''))")
+if [ "$GOOGLE_CLIENT_ID_ESCAPED" = '""' ]; then
+  log "WARNING: GOOGLE_CLIENT_ID is not set; Google sign-in will show a configuration error."
+fi
+cat > "$BUILD_DIR/gtc-config.js" <<EOF
+window.__GTC_CONFIG = Object.freeze({
+  googleClientId: ${GOOGLE_CLIENT_ID_ESCAPED}
+});
+EOF
+
 SUDO=""
 if [ "$(id -u)" -ne 0 ]; then
   if command -v sudo >/dev/null 2>&1; then

--- a/var/www/gtc-form/auth/google/index.html
+++ b/var/www/gtc-form/auth/google/index.html
@@ -89,9 +89,9 @@
     <a class="link" href="/auth/">Back to all options</a>
   </main>
 
+  <script src="/gtc-config.js"></script>
   <script>
-    const GOOGLE_CLIENT_ID = 'REPLACE_WITH_GOOGLE_CLIENT_ID';
-
+    const runtimeConfig = window.__GTC_CONFIG ?? {};
     const errorBox = document.getElementById('error');
 
     function showError(message) {
@@ -143,13 +143,17 @@
         });
     }
 
-    function initializeGoogleButton() {
+    function initializeGoogleButton(clientId) {
+      if (!clientId) {
+        showError('Google sign-in is not configured yet. Please contact support.');
+        return;
+      }
       if (!window.google || !window.google.accounts || !window.google.accounts.id) {
         showError('Google services are not available right now. Please refresh the page.');
         return;
       }
       window.google.accounts.id.initialize({
-        client_id: GOOGLE_CLIENT_ID,
+        client_id: clientId,
         callback: handleCredentialResponse,
         ux_mode: 'popup'
       });
@@ -165,7 +169,9 @@
       );
     }
 
-    window.addEventListener('load', initializeGoogleButton);
+    window.addEventListener('load', () => {
+      initializeGoogleButton(runtimeConfig.googleClientId);
+    });
   </script>
 </body>
 </html>

--- a/var/www/gtc-form/gtc-config.js
+++ b/var/www/gtc-form/gtc-config.js
@@ -1,0 +1,3 @@
+window.__GTC_CONFIG = Object.freeze({
+  googleClientId: ''
+});


### PR DESCRIPTION
## Summary
- load the Google sign-in page client ID from a runtime configuration script and show a clear error when it is missing
- generate gtc-config.js during deploys from the GOOGLE_CLIENT_ID environment variable and document the deployment step for operators

## Testing
- bash -n deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9903180b4832a8a900cce71ab4c01