### PR TITLE
Add subscription verification before entering chat

### DIFF
--- a/srv/gtc-auth/db.js
+++ b/srv/gtc-auth/db.js
@@ -96,3 +96,67 @@ export async function useVerifyToken(token) {
   );
   return rows[0] || null;
 }
+
+const ACTIVE_STATUSES = ['active', 'trialing'];
+
+function isRelationMissing(error) {
+  return error && error.code === '42P01';
+}
+
+function isColumnMissing(error) {
+  return error && error.code === '42703';
+}
+
+export async function getLatestEntitlement(userId) {
+  if (!userId) return null;
+
+  const params = [userId];
+  try {
+    const { rows } = await pool.query(
+      `SELECT status, end_date, livemode
+         FROM public.v_user_entitlement
+        WHERE gtc_user_id=$1
+        ORDER BY end_date DESC NULLS LAST
+        LIMIT 1`,
+      params
+    );
+    if (rows[0]) return rows[0];
+  } catch (error) {
+    if (!isRelationMissing(error)) throw error;
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT status, end_date, livemode
+         FROM public.subscriptions
+        WHERE gtc_user_id=$1
+        ORDER BY end_date DESC NULLS LAST
+        LIMIT 1`,
+      params
+    );
+    if (rows[0]) return rows[0];
+  } catch (error) {
+    if (!isRelationMissing(error) && !isColumnMissing(error)) throw error;
+    const { rows } = await pool.query(
+      `SELECT status, end_date
+         FROM public.subscriptions
+        WHERE gtc_user_id=$1
+        ORDER BY end_date DESC NULLS LAST
+        LIMIT 1`,
+      params
+    );
+    if (rows[0]) return rows[0];
+  }
+
+  return null;
+}
+
+export function isEntitlementActive(record) {
+  if (!record) return false;
+  const status = record.status ? String(record.status).toLowerCase() : '';
+  if (!ACTIVE_STATUSES.includes(status)) return false;
+  if (!record.end_date) return true;
+  const expiresAt = new Date(record.end_date);
+  if (Number.isNaN(expiresAt.getTime())) return true;
+  return expiresAt.getTime() > Date.now();
+}

--- a/srv/gtc-auth/server.js
+++ b/srv/gtc-auth/server.js
@@ -14,7 +14,9 @@ import {
   useVerifyToken,
   setEmailVerified,
   getGoogleBySub,
-  createGoogleUser
+  createGoogleUser,
+  getLatestEntitlement,
+  isEntitlementActive
 } from './db.js';
 import { sendVerificationEmail } from './mail.js';
 import { verifyGoogleCredential } from './google.js';
@@ -161,6 +163,37 @@ app.post('/auth/google', async (req, res) => {
     return res.json({ gtc_user_id: newId, email });
   } catch (e) {
     res.status(401).json({ code: 'invalid_google_token' });
+  }
+});
+
+app.get('/auth/subscription_status', async (req, res) => {
+  const { gtc_user_id: rawId } = req.query || {};
+  if (!rawId) return res.status(400).json({ code: 'bad_request' });
+
+  const trimmed = String(rawId).trim();
+  if (!trimmed) return res.status(400).json({ code: 'bad_request' });
+
+  try {
+    const entitlement = await getLatestEntitlement(trimmed);
+    if (!entitlement) {
+      return res.json({ active: false, status: null, expires_at: null });
+    }
+
+    const active = isEntitlementActive(entitlement);
+    const payload = {
+      active,
+      status: entitlement.status ?? null,
+      expires_at: entitlement.end_date ?? null
+    };
+
+    if (Object.prototype.hasOwnProperty.call(entitlement, 'livemode')) {
+      payload.livemode = entitlement.livemode;
+    }
+
+    res.json(payload);
+  } catch (error) {
+    console.error('subscription_status error', error);
+    res.status(500).json({ code: 'server_error' });
   }
 });
 

--- a/var/www/gtc-form/auth/email/index.html
+++ b/var/www/gtc-form/auth/email/index.html
@@ -329,6 +329,42 @@
       return response.json();
     }
 
+    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
+    const PAYMENT_RETURN_PATH = '/chat';
+
+    function buildPaymentUrl(userId) {
+      const url = new URL(PAYMENT_BASE_URL);
+      url.searchParams.set('user_id', userId);
+      url.searchParams.set('returnTo', PAYMENT_RETURN_PATH);
+      return url.toString();
+    }
+
+    async function redirectAfterEntitlementCheck(userId) {
+      const endpoint = `/auth/subscription_status?gtc_user_id=${encodeURIComponent(userId)}`;
+      let response;
+      try {
+        response = await fetch(endpoint, { method: 'GET' });
+      } catch (error) {
+        const err = new Error('subscription_check_failed');
+        err.cause = error;
+        throw err;
+      }
+
+      if (!response.ok) {
+        const err = new Error('subscription_check_failed');
+        err.status = response.status;
+        throw err;
+      }
+
+      const data = await response.json();
+      if (data && data.active) {
+        window.location.href = PAYMENT_RETURN_PATH;
+        return;
+      }
+
+      window.location.href = buildPaymentUrl(userId);
+    }
+
     emailForm.addEventListener('submit', async (event) => {
       event.preventDefault();
       showError(emailError, '');
@@ -366,10 +402,16 @@
       setLoading(true);
       try {
         const data = await postJSON('/auth/login', { email: currentEmail, password });
-        localStorage.setItem('gtc_user_id', String(data.gtc_user_id));
+        const userId = String(data.gtc_user_id);
+        localStorage.setItem('gtc_user_id', userId);
         localStorage.setItem('email', data.email);
-        window.location.href = '/chat';
+        await redirectAfterEntitlementCheck(userId);
+        return;
       } catch (error) {
+        if (error.message === 'subscription_check_failed') {
+          showError(signinError, 'We were unable to confirm your subscription status. Please try again.');
+          return;
+        }
         if (error.status === 401) {
           showError(signinError, 'Invalid email or password.');
         } else if (error.status === 403 && error.body?.code === 'email_not_verified') {

--- a/var/www/gtc-form/auth/google/index.html
+++ b/var/www/gtc-form/auth/google/index.html
@@ -117,6 +117,42 @@
       return response.json();
     }
 
+    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
+    const PAYMENT_RETURN_PATH = '/chat';
+
+    function buildPaymentUrl(userId) {
+      const url = new URL(PAYMENT_BASE_URL);
+      url.searchParams.set('user_id', userId);
+      url.searchParams.set('returnTo', PAYMENT_RETURN_PATH);
+      return url.toString();
+    }
+
+    async function redirectAfterEntitlementCheck(userId) {
+      const endpoint = `/auth/subscription_status?gtc_user_id=${encodeURIComponent(userId)}`;
+      let response;
+      try {
+        response = await fetch(endpoint);
+      } catch (error) {
+        const err = new Error('subscription_check_failed');
+        err.cause = error;
+        throw err;
+      }
+
+      if (!response.ok) {
+        const err = new Error('subscription_check_failed');
+        err.status = response.status;
+        throw err;
+      }
+
+      const data = await response.json();
+      if (data && data.active) {
+        window.location.href = PAYMENT_RETURN_PATH;
+        return;
+      }
+
+      window.location.href = buildPaymentUrl(userId);
+    }
+
     function handleCredentialResponse(response) {
       showError('');
       const credential = response.credential;
@@ -125,12 +161,17 @@
         return;
       }
       postJSON('/auth/google', { google_credential: credential })
-        .then((data) => {
-          localStorage.setItem('gtc_user_id', String(data.gtc_user_id));
+        .then(async (data) => {
+          const userId = String(data.gtc_user_id);
+          localStorage.setItem('gtc_user_id', userId);
           localStorage.setItem('email', data.email);
-          window.location.href = '/chat';
+          await redirectAfterEntitlementCheck(userId);
         })
         .catch((error) => {
+          if (error.message === 'subscription_check_failed') {
+            showError('We were unable to confirm your subscription status. Please try again.');
+            return;
+          }
           if (error.body?.code === 'email_not_verified') {
             showError('Your email is not verified yet. Please verify before continuing.');
           } else if (error.status === 401) {

--- a/var/www/gtc-form/verify/index.html
+++ b/var/www/gtc-form/verify/index.html
@@ -170,6 +170,42 @@
       return response.json();
     }
 
+    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
+    const PAYMENT_RETURN_PATH = '/chat';
+
+    function buildPaymentUrl(userId) {
+      const url = new URL(PAYMENT_BASE_URL);
+      url.searchParams.set('user_id', userId);
+      url.searchParams.set('returnTo', PAYMENT_RETURN_PATH);
+      return url.toString();
+    }
+
+    async function redirectAfterEntitlementCheck(userId) {
+      const endpoint = `/auth/subscription_status?gtc_user_id=${encodeURIComponent(userId)}`;
+      let response;
+      try {
+        response = await fetch(endpoint);
+      } catch (error) {
+        const err = new Error('subscription_check_failed');
+        err.cause = error;
+        throw err;
+      }
+
+      if (!response.ok) {
+        const err = new Error('subscription_check_failed');
+        err.status = response.status;
+        throw err;
+      }
+
+      const data = await response.json();
+      if (data && data.active) {
+        window.location.href = PAYMENT_RETURN_PATH;
+        return;
+      }
+
+      window.location.href = buildPaymentUrl(userId);
+    }
+
     function getTokenFromQuery() {
       const params = new URLSearchParams(window.location.search);
       return params.get('token');
@@ -199,8 +235,24 @@
       }
     }
 
-    continueButton.addEventListener('click', () => {
-      window.location.href = '/chat';
+    continueButton.addEventListener('click', async () => {
+      const storedUserId = localStorage.getItem('gtc_user_id');
+      if (!storedUserId) {
+        showStatus('Missing account information. Please sign in again.', 'error');
+        return;
+      }
+
+      continueButton.disabled = true;
+      showStatus('Checking your subscription status...', 'success');
+      loadingIndicator.hidden = false;
+
+      try {
+        await redirectAfterEntitlementCheck(storedUserId);
+      } catch (error) {
+        continueButton.disabled = false;
+        loadingIndicator.hidden = true;
+        showStatus('We could not confirm your subscription status. Please try again.', 'error');
+      }
     });
 
     verifyEmail();


### PR DESCRIPTION
## Summary
- add database helpers to load the latest subscription entitlement and detect active access
- expose a new /auth/subscription_status endpoint to report subscription status by gtc_user_id
- redirect email, google, and verification flows to chat or payment based on the subscription check

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfb842d43c832a9acc3d9d521f7e06