### PR TITLE
Add subscription verification and chat stub

### DIFF
--- a/srv/gtc-auth/db.js
+++ b/srv/gtc-auth/db.js
@@ -1,6 +1,8 @@
 import pg from 'pg';
 const { Pool } = pg;
 
+export { isEntitlementActive } from './entitlement.js';
+
 export const pool = new Pool({
   host: process.env.PGHOST,
   port: +process.env.PGPORT,
@@ -78,7 +80,9 @@ export async function setEmailVerified(userId, email) {
 
 export async function createVerifyToken(userId, email, ttlMinutes = 60) {
   const { rows } = await pool.query(
-    'INSERT INTO public.auth_verification(token,user_id,email,expires_at) VALUES (gen_random_uuid(),$1,$2,now() + ($3 || '' minutes'')::interval) RETURNING token',
+    `INSERT INTO public.auth_verification(token,user_id,email,expires_at)
+     VALUES (gen_random_uuid(),$1,$2,now() + ($3 || ' minutes')::interval)
+     RETURNING token`,
     [userId, email, ttlMinutes]
   );
   return rows[0].token;
@@ -95,4 +99,56 @@ export async function useVerifyToken(token) {
     [token]
   );
   return rows[0] || null;
+}
+
+function isRelationMissing(error) {
+  return error && error.code === '42P01';
+}
+
+function isColumnMissing(error) {
+  return error && error.code === '42703';
+}
+
+export async function getLatestEntitlement(userId) {
+  if (!userId) return null;
+
+  const params = [userId];
+  try {
+    const { rows } = await pool.query(
+      `SELECT status, end_date, livemode
+         FROM public.v_user_entitlement
+        WHERE gtc_user_id=$1
+        ORDER BY end_date DESC NULLS LAST
+        LIMIT 1`,
+      params
+    );
+    if (rows[0]) return rows[0];
+  } catch (error) {
+    if (!isRelationMissing(error)) throw error;
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `SELECT status, end_date, livemode
+         FROM public.subscriptions
+        WHERE gtc_user_id=$1
+        ORDER BY end_date DESC NULLS LAST
+        LIMIT 1`,
+      params
+    );
+    if (rows[0]) return rows[0];
+  } catch (error) {
+    if (!isRelationMissing(error) && !isColumnMissing(error)) throw error;
+    const { rows } = await pool.query(
+      `SELECT status, end_date
+         FROM public.subscriptions
+        WHERE gtc_user_id=$1
+        ORDER BY end_date DESC NULLS LAST
+        LIMIT 1`,
+      params
+    );
+    if (rows[0]) return rows[0];
+  }
+
+  return null;
 }

--- a/srv/gtc-auth/entitlement.js
+++ b/srv/gtc-auth/entitlement.js
@@ -1,0 +1,13 @@
+const ACTIVE_STATUSES = ['active', 'trialing'];
+
+export function isEntitlementActive(record) {
+  if (!record) return false;
+  const status = record.status ? String(record.status).toLowerCase() : '';
+  if (!ACTIVE_STATUSES.includes(status)) return false;
+  if (!record.end_date) return true;
+  const expiresAt = new Date(record.end_date);
+  if (Number.isNaN(expiresAt.getTime())) return true;
+  return expiresAt.getTime() > Date.now();
+}
+
+export { ACTIVE_STATUSES };

--- a/srv/gtc-auth/server.js
+++ b/srv/gtc-auth/server.js
@@ -14,7 +14,9 @@ import {
   useVerifyToken,
   setEmailVerified,
   getGoogleBySub,
-  createGoogleUser
+  createGoogleUser,
+  getLatestEntitlement,
+  isEntitlementActive
 } from './db.js';
 import { sendVerificationEmail } from './mail.js';
 import { verifyGoogleCredential } from './google.js';
@@ -161,6 +163,37 @@ app.post('/auth/google', async (req, res) => {
     return res.json({ gtc_user_id: newId, email });
   } catch (e) {
     res.status(401).json({ code: 'invalid_google_token' });
+  }
+});
+
+app.get('/auth/subscription_status', async (req, res) => {
+  const { gtc_user_id: rawId } = req.query || {};
+  if (!rawId) return res.status(400).json({ code: 'bad_request' });
+
+  const trimmed = String(rawId).trim();
+  if (!trimmed) return res.status(400).json({ code: 'bad_request' });
+
+  try {
+    const entitlement = await getLatestEntitlement(trimmed);
+    if (!entitlement) {
+      return res.json({ active: false, status: null, expires_at: null });
+    }
+
+    const active = isEntitlementActive(entitlement);
+    const payload = {
+      active,
+      status: entitlement.status ?? null,
+      expires_at: entitlement.end_date ?? null
+    };
+
+    if (Object.prototype.hasOwnProperty.call(entitlement, 'livemode')) {
+      payload.livemode = entitlement.livemode;
+    }
+
+    res.json(payload);
+  } catch (error) {
+    console.error('subscription_status error', error);
+    res.status(500).json({ code: 'server_error' });
   }
 });
 

--- a/srv/gtc-auth/tests/subscription-status.test.js
+++ b/srv/gtc-auth/tests/subscription-status.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isEntitlementActive } from '../entitlement.js';
+
+test('inactive when record is null', () => {
+  assert.equal(isEntitlementActive(null), false);
+});
+
+test('inactive when status missing', () => {
+  assert.equal(isEntitlementActive({}), false);
+});
+
+test('inactive when status not active', () => {
+  assert.equal(
+    isEntitlementActive({ status: 'canceled', end_date: new Date(Date.now() + 3600_000).toISOString() }),
+    false
+  );
+});
+
+test('active when status active without end_date', () => {
+  assert.equal(isEntitlementActive({ status: 'active', end_date: null }), true);
+});
+
+test('active when not expired', () => {
+  const future = new Date(Date.now() + 86400_000).toISOString();
+  assert.equal(isEntitlementActive({ status: 'trialing', end_date: future }), true);
+});
+
+test('inactive when expired', () => {
+  const past = new Date(Date.now() - 86400_000).toISOString();
+  assert.equal(isEntitlementActive({ status: 'active', end_date: past }), false);
+});

--- a/var/www/gtc-form/auth/email/index.html
+++ b/var/www/gtc-form/auth/email/index.html
@@ -329,6 +329,42 @@
       return response.json();
     }
 
+    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
+    const CHAT_DESTINATION_URL = 'https://app.gtstor.com/chat/';
+
+    function buildPaymentUrl(userId) {
+      const url = new URL(PAYMENT_BASE_URL);
+      url.searchParams.set('user_id', userId);
+      url.searchParams.set('returnTo', CHAT_DESTINATION_URL);
+      return url.toString();
+    }
+
+    async function redirectAfterEntitlementCheck(userId) {
+      const endpoint = `/auth/subscription_status?gtc_user_id=${encodeURIComponent(userId)}`;
+      let response;
+      try {
+        response = await fetch(endpoint, { method: 'GET' });
+      } catch (error) {
+        const err = new Error('subscription_check_failed');
+        err.cause = error;
+        throw err;
+      }
+
+      if (!response.ok) {
+        const err = new Error('subscription_check_failed');
+        err.status = response.status;
+        throw err;
+      }
+
+      const data = await response.json();
+      if (data && data.active) {
+        window.location.href = CHAT_DESTINATION_URL;
+        return;
+      }
+
+      window.location.href = buildPaymentUrl(userId);
+    }
+
     emailForm.addEventListener('submit', async (event) => {
       event.preventDefault();
       showError(emailError, '');
@@ -366,10 +402,16 @@
       setLoading(true);
       try {
         const data = await postJSON('/auth/login', { email: currentEmail, password });
-        localStorage.setItem('gtc_user_id', String(data.gtc_user_id));
+        const userId = String(data.gtc_user_id);
+        localStorage.setItem('gtc_user_id', userId);
         localStorage.setItem('email', data.email);
-        window.location.href = '/chat';
+        await redirectAfterEntitlementCheck(userId);
+        return;
       } catch (error) {
+        if (error.message === 'subscription_check_failed') {
+          showError(signinError, 'We were unable to confirm your subscription status. Please try again.');
+          return;
+        }
         if (error.status === 401) {
           showError(signinError, 'Invalid email or password.');
         } else if (error.status === 403 && error.body?.code === 'email_not_verified') {

--- a/var/www/gtc-form/auth/email/index.html
+++ b/var/www/gtc-form/auth/email/index.html
@@ -179,6 +179,7 @@
       }
     }
   </style>
+  <script src="/gtc-config.js"></script>
 </head>
 <body>
   <main>
@@ -238,6 +239,8 @@
   </main>
 
   <script>
+    const runtimeConfig = window.__GTC_CONFIG ?? {};
+
     const emailForm = document.getElementById('email-form');
     const signinForm = document.getElementById('signin-form');
     const registerForm = document.getElementById('register-form');
@@ -329,8 +332,8 @@
       return response.json();
     }
 
-    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
-    const CHAT_DESTINATION_URL = 'https://app.gtstor.com/chat/';
+    const PAYMENT_BASE_URL = runtimeConfig.paymentBaseUrl || 'https://pay.gtstor.com/payment.php';
+    const CHAT_DESTINATION_URL = runtimeConfig.chatDestinationUrl || 'https://app.gtstor.com/chat/';
 
     function buildPaymentUrl(userId) {
       const url = new URL(PAYMENT_BASE_URL);

--- a/var/www/gtc-form/auth/google/index.html
+++ b/var/www/gtc-form/auth/google/index.html
@@ -117,6 +117,42 @@
       return response.json();
     }
 
+    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
+    const CHAT_DESTINATION_URL = 'https://app.gtstor.com/chat/';
+
+    function buildPaymentUrl(userId) {
+      const url = new URL(PAYMENT_BASE_URL);
+      url.searchParams.set('user_id', userId);
+      url.searchParams.set('returnTo', CHAT_DESTINATION_URL);
+      return url.toString();
+    }
+
+    async function redirectAfterEntitlementCheck(userId) {
+      const endpoint = `/auth/subscription_status?gtc_user_id=${encodeURIComponent(userId)}`;
+      let response;
+      try {
+        response = await fetch(endpoint);
+      } catch (error) {
+        const err = new Error('subscription_check_failed');
+        err.cause = error;
+        throw err;
+      }
+
+      if (!response.ok) {
+        const err = new Error('subscription_check_failed');
+        err.status = response.status;
+        throw err;
+      }
+
+      const data = await response.json();
+      if (data && data.active) {
+        window.location.href = CHAT_DESTINATION_URL;
+        return;
+      }
+
+      window.location.href = buildPaymentUrl(userId);
+    }
+
     function handleCredentialResponse(response) {
       showError('');
       const credential = response.credential;
@@ -125,12 +161,17 @@
         return;
       }
       postJSON('/auth/google', { google_credential: credential })
-        .then((data) => {
-          localStorage.setItem('gtc_user_id', String(data.gtc_user_id));
+        .then(async (data) => {
+          const userId = String(data.gtc_user_id);
+          localStorage.setItem('gtc_user_id', userId);
           localStorage.setItem('email', data.email);
-          window.location.href = '/chat';
+          await redirectAfterEntitlementCheck(userId);
         })
         .catch((error) => {
+          if (error.message === 'subscription_check_failed') {
+            showError('We were unable to confirm your subscription status. Please try again.');
+            return;
+          }
           if (error.body?.code === 'email_not_verified') {
             showError('Your email is not verified yet. Please verify before continuing.');
           } else if (error.status === 401) {

--- a/var/www/gtc-form/auth/google/index.html
+++ b/var/www/gtc-form/auth/google/index.html
@@ -117,8 +117,8 @@
       return response.json();
     }
 
-    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
-    const CHAT_DESTINATION_URL = 'https://app.gtstor.com/chat/';
+    const PAYMENT_BASE_URL = runtimeConfig.paymentBaseUrl || 'https://pay.gtstor.com/payment.php';
+    const CHAT_DESTINATION_URL = runtimeConfig.chatDestinationUrl || 'https://app.gtstor.com/chat/';
 
     function buildPaymentUrl(userId) {
       const url = new URL(PAYMENT_BASE_URL);

--- a/var/www/gtc-form/chat/index.html
+++ b/var/www/gtc-form/chat/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GTChain Chat (Preview)</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(15, 23, 42, 0.05));
+      color: #0f172a;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 16px;
+    }
+
+    main {
+      width: min(640px, 100%);
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 24px;
+      padding: 48px 40px;
+      box-shadow: 0 35px 60px rgba(15, 23, 42, 0.18);
+      backdrop-filter: blur(12px);
+      text-align: center;
+    }
+
+    h1 {
+      margin: 0 0 16px;
+      font-size: clamp(2rem, 5vw, 2.75rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    p {
+      margin: 0 0 28px;
+      font-size: 1.05rem;
+      color: #475569;
+      line-height: 1.6;
+    }
+
+    a.button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 14px 24px;
+      border-radius: 14px;
+      background: #0f172a;
+      color: #ffffff;
+      font-weight: 600;
+      font-size: 1rem;
+      text-decoration: none;
+      box-shadow: 0 18px 30px rgba(15, 23, 42, 0.25);
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    a.button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 24px 40px rgba(15, 23, 42, 0.28);
+    }
+
+    .note {
+      margin-top: 24px;
+      font-size: 0.9rem;
+      color: #94a3b8;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Chat preview coming soon</h1>
+    <p>
+      You have successfully reached the chat area placeholder. The full conversational experience is
+      under construction, but you can continue testing access flow and subscription redirects here.
+    </p>
+    <a class="button" href="https://app.gtstor.com/chat/" target="_blank" rel="noopener">Open hosted chat stub</a>
+    <p class="note">Keep this tab open to validate successful logins while development continues.</p>
+  </main>
+</body>
+</html>

--- a/var/www/gtc-form/gtc-config.js
+++ b/var/www/gtc-form/gtc-config.js
@@ -1,3 +1,5 @@
 window.__GTC_CONFIG = Object.freeze({
-  googleClientId: ''
+  googleClientId: '',
+  paymentBaseUrl: 'https://pay.gtstor.com/payment.php',
+  chatDestinationUrl: 'https://app.gtstor.com/chat/'
 });

--- a/var/www/gtc-form/verify/index.html
+++ b/var/www/gtc-form/verify/index.html
@@ -170,6 +170,42 @@
       return response.json();
     }
 
+    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
+    const CHAT_DESTINATION_URL = 'https://app.gtstor.com/chat/';
+
+    function buildPaymentUrl(userId) {
+      const url = new URL(PAYMENT_BASE_URL);
+      url.searchParams.set('user_id', userId);
+      url.searchParams.set('returnTo', CHAT_DESTINATION_URL);
+      return url.toString();
+    }
+
+    async function redirectAfterEntitlementCheck(userId) {
+      const endpoint = `/auth/subscription_status?gtc_user_id=${encodeURIComponent(userId)}`;
+      let response;
+      try {
+        response = await fetch(endpoint);
+      } catch (error) {
+        const err = new Error('subscription_check_failed');
+        err.cause = error;
+        throw err;
+      }
+
+      if (!response.ok) {
+        const err = new Error('subscription_check_failed');
+        err.status = response.status;
+        throw err;
+      }
+
+      const data = await response.json();
+      if (data && data.active) {
+        window.location.href = CHAT_DESTINATION_URL;
+        return;
+      }
+
+      window.location.href = buildPaymentUrl(userId);
+    }
+
     function getTokenFromQuery() {
       const params = new URLSearchParams(window.location.search);
       return params.get('token');
@@ -199,8 +235,24 @@
       }
     }
 
-    continueButton.addEventListener('click', () => {
-      window.location.href = '/chat';
+    continueButton.addEventListener('click', async () => {
+      const storedUserId = localStorage.getItem('gtc_user_id');
+      if (!storedUserId) {
+        showStatus('Missing account information. Please sign in again.', 'error');
+        return;
+      }
+
+      continueButton.disabled = true;
+      showStatus('Checking your subscription status...', 'success');
+      loadingIndicator.hidden = false;
+
+      try {
+        await redirectAfterEntitlementCheck(storedUserId);
+      } catch (error) {
+        continueButton.disabled = false;
+        loadingIndicator.hidden = true;
+        showStatus('We could not confirm your subscription status. Please try again.', 'error');
+      }
     });
 
     verifyEmail();

--- a/var/www/gtc-form/verify/index.html
+++ b/var/www/gtc-form/verify/index.html
@@ -126,6 +126,7 @@
       }
     }
   </style>
+  <script src="/gtc-config.js"></script>
 </head>
 <body>
   <main>
@@ -142,6 +143,8 @@
   </main>
 
   <script>
+    const runtimeConfig = window.__GTC_CONFIG ?? {};
+
     const statusBox = document.getElementById('status');
     const loadingIndicator = document.getElementById('loading');
     const actions = document.getElementById('actions');
@@ -170,8 +173,8 @@
       return response.json();
     }
 
-    const PAYMENT_BASE_URL = 'https://pay.gtstor.com/payment.php';
-    const CHAT_DESTINATION_URL = 'https://app.gtstor.com/chat/';
+    const PAYMENT_BASE_URL = runtimeConfig.paymentBaseUrl || 'https://pay.gtstor.com/payment.php';
+    const CHAT_DESTINATION_URL = runtimeConfig.chatDestinationUrl || 'https://app.gtstor.com/chat/';
 
     function buildPaymentUrl(userId) {
       const url = new URL(PAYMENT_BASE_URL);


### PR DESCRIPTION
## Summary
- add database helpers to load the latest subscription entitlement and detect active access
- expose a new /auth/subscription_status endpoint to report subscription status by gtc_user_id
- redirect email, google, and verification flows to chat or payment based on the subscription check
- add a static chat placeholder and point successful entitlement checks to the hosted chat stub URL
- cover the entitlement activity helper with a node:test suite

## Testing
- node --test srv/gtc-auth/tests/subscription-status.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dfb842d43c832a9acc3d9d521f7e06