### PR TITLE
Fix entitlement redirect rawEntitlement reference

### DIFF
--- a/srv/gtc-auth/post-auth-redirect.js
+++ b/srv/gtc-auth/post-auth-redirect.js
@@ -148,7 +148,12 @@ export async function determinePostAuthRedirect({
     const entitlement = await fetchEntitlement(normalizedId);
     const isActive = isEntitlementActive(entitlement);
     const location = isActive ? buildChatRedirect(forwarded) : buildPaymentRedirect(normalizedId, forwarded);
-    return { location, isActive, entitlement, rawEntitlement };
+    return {
+      location,
+      isActive,
+      entitlement,
+      rawEntitlement: entitlement
+    };
   } catch (error) {
     const fallback = buildPaymentRedirect(normalizedId, forwarded);
     return { location: fallback, error };

--- a/srv/gtc-auth/tests/post-auth-redirect.test.mjs
+++ b/srv/gtc-auth/tests/post-auth-redirect.test.mjs
@@ -17,6 +17,16 @@ test('string flag from RPC still routes active subscribers to chat', async () =>
   assert.equal(decision.isActive, true);
 });
 
+test('rawEntitlement mirrors the RPC payload for downstream logging', async () => {
+  const entitlement = { is_active: true, status: 'active' };
+  const decision = await determinePostAuthRedirect({
+    gtcUserId: '3001',
+    fetchEntitlement: async () => entitlement
+  });
+  assert.equal(decision.entitlement, entitlement);
+  assert.equal(decision.rawEntitlement, entitlement);
+});
+
 test('status + future end_date imply activity when boolean flag missing', async () => {
   const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
   const decision = await determinePostAuthRedirect({


### PR DESCRIPTION
## Summary
- fix the post-auth redirect success path to return the entitlement payload without throwing
- add a regression test to ensure the rawEntitlement field mirrors the RPC payload

## Testing
- npm test --prefix srv/gtc-auth

------
https://chatgpt.com/codex/tasks/task_e_68f143c42ec4832ab3855d4e685f8b96