### PR TITLE
Prioritize active SQL subscriptions during redirect

### DIFF
--- a/Docs/infrastructure.md
+++ b/Docs/infrastructure.md
@@ -59,7 +59,7 @@ This document describes the current configuration, software stack, and automatio
 | 2 | `gtc-auth` | PostgreSQL (`gtc_db`) | Creates records in `public."user"`, `auth_email`, `auth_google`, and verification tokens. |
 | 3 | Registration form / payment portal | Stripe billing | Payment links include `gtc_user_id` query parameter so Stripe session metadata references the user. |
 | 4 | Stripe webhook → n8n | PostgreSQL (`public.subscriptions`) | `Save Subscription` node writes subscription rows keyed by `gtc_user_id`; rejects payloads without the identifier. |
-| 5 | `gtc-auth` entitlement checks | PostgREST RPC (`subscription_status`) | `fetchSubscriptionStatus` queries the RPC and drives the `/auth/finish` redirect (chat vs payment). |
+| 5 | `gtc-auth` entitlement checks | PostgreSQL query (`public.subscriptions`) | `fetchSubscriptionStatus` reads subscription rows directly from SQL and drives the `/auth/finish` redirect (chat vs payment). |
 
 ### Registered User Data Persistence
 

--- a/docs/gtc-auth.md
+++ b/docs/gtc-auth.md
@@ -32,11 +32,11 @@
 3. `POST /auth/request_email_verification` — повторная отправка письма (опционально, только для неподтверждённых адресов).
 4. Пользователь переходит по ссылке из письма (`/verify?token=UUID` на клиенте), который затем вызывает `POST /auth/verify`.
 5. `POST /auth/login` — вход возможен только после подтверждения email.
-6. Клиент перенаправляется на `/auth/finish`, где бэкенд выполняет RPC `subscription_status` и решает, куда отправить пользователя (на `https://app.gtstor.com/chat/` или на платёжку).
+6. Клиент перенаправляется на `/auth/finish`, где бэкенд выполняет SQL-запрос к `public.subscriptions` и решает, куда отправить пользователя (на `https://app.gtstor.com/chat/` или на платёжку).
 
-> После логина решение принимается **только** на основе RPC в GTC DB; автоматические переходы в Stripe Customer Portal запрещены.
+> После логина решение принимается **только** на основе данных PostgreSQL в GTC DB; автоматические переходы в Stripe Customer Portal запрещены.
 
-> После логина решение принимается **только** на основе RPC в GTC DB; автоматические переходы в Stripe Customer Portal запрещены.
+> После логина решение принимается **только** на основе данных PostgreSQL в GTC DB; автоматические переходы в Stripe Customer Portal запрещены.
 
 ### 2.2 Вход через Google
 
@@ -44,7 +44,7 @@
 2. `POST /auth/google` отправляет credential в сервис.
 3. `verifyGoogleCredential` валидирует токен и извлекает поля `email` и `sub`.
 4. Если `sub` уже известен — возвращается существующий пользователь; иначе email связывается с новым или уже подтверждённым пользователем.
-5. После успешного ответа фронт редиректит на `/auth/finish` для проверки подписки через RPC.
+5. После успешного ответа фронт редиректит на `/auth/finish` для проверки подписки через прямой SQL-запрос.
 
 > Управление подпиской через Stripe доступно лишь по явному запросу пользователя (например, кнопка «Manage subscription») и не участвует в пост-логине.
 
@@ -78,9 +78,9 @@ request_email_verification → (письмо) → verify
 | `public.auth_email` | `email` (PK), `user_id`, `pwd_hash`, `email_verified`, `created_at` | Учетная запись с паролем и состоянием подтверждения email. |
 | `public.auth_google` | `google_sub` (PK), `user_id`, `email`, `created_at` | Привязки Google SSO (каждый `sub` и email уникальны). |
 | `public.auth_verification` | `token` (PK), `user_id`, `email`, `expires_at`, `used`, `created_at` | Одноразовые токены подтверждения email (TTL по умолчанию 60 минут). |
-| `public.subscriptions` | `subscription_id` (PK), `gtc_user_id` (NOT NULL), `status`, `start_date`, `end_date`, `stripe_customer_id`, `stripe_subscription_id`, `plan_code`, `stripe_price_id`, `stripe_product_id`, `created_at`, `updated_at`, `livemode` | Записи о подписках, которые создаёт нода n8n «Save Subscription». Используются RPC `subscription_status` (через `fetchSubscriptionStatus`) для проверки права доступа в чат. |
+| `public.subscriptions` | `subscription_id` (PK), `gtc_user_id` (NOT NULL), `status`, `start_date`, `end_date`, `stripe_customer_id`, `stripe_subscription_id`, `plan_code`, `stripe_price_id`, `stripe_product_id`, `created_at`, `updated_at`, `livemode` | Записи о подписках, которые создаёт нода n8n «Save Subscription». Используются прямые SQL-запросы (`fetchSubscriptionStatus`) для проверки права доступа в чат. |
 
-> `fetchSubscriptionStatus` всегда вызывает RPC через серверный HTTP-клиент: при отсутствии глобального `fetch` в рантайме Node.js используется встроенный `node-fetch` полифилл, поэтому проверка подписки не зависит от версии Node или наличия браузерных API.
+> `fetchSubscriptionStatus` выполняет прямой запрос `SELECT ... FROM public.subscriptions WHERE gtc_user_id=$1`, сортирует по `end_date`/`updated_at` и вычисляет `is_active` на бэкенде; внешние HTTP RPC не используются.
 
 Дополнительные индексы (`idx_auth_email_user`, `idx_auth_google_user`, `idx_auth_verif_user`) ускоряют запросы по `user_id` при связке профилей и аудите.
 

--- a/srv/gtc-auth/.env.example
+++ b/srv/gtc-auth/.env.example
@@ -36,6 +36,3 @@ AUTH_COOKIE_DOMAIN=.gtstor.com
 AUTH_COOKIE_SECURE=true
 AUTH_COOKIE_MAX_AGE_MS=600000
 
-# Entitlement RPC
-ENTITLEMENT_RPC_URL=https://app.gtstor.com/api/rpc/subscription_status
-ENTITLEMENT_TIMEOUT_MS=2500

--- a/srv/gtc-auth/README.md
+++ b/srv/gtc-auth/README.md
@@ -29,7 +29,7 @@ Key variables for the post-auth redirect pipeline:
 
 - `PAYMENT_PORTAL_URL` — hosted payment page that accepts `user_id` in the query string.
 - `CHAT_REDIRECT_PATH` — relative path to the chat workspace (defaults to `/chat/`).
-- `ENTITLEMENT_RPC_URL` / `ENTITLEMENT_TIMEOUT_MS` — PostgREST RPC used to resolve subscription status.
+- `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` — connection parameters for the GTC1 PostgreSQL cluster that stores subscription data.
 - `AUTH_COOKIE_NAME`, `AUTH_COOKIE_DOMAIN`, `AUTH_COOKIE_SECURE`, `AUTH_COOKIE_MAX_AGE_MS` — configure the transient cookie that stores `gtc_user_id` between `/auth/*` handlers and `/auth/finish`.
 
 ## Install & run
@@ -86,16 +86,16 @@ Response: `{ "gtc_user_id": 123, "email": "user@example.com" }`
 Successful auth responses also set an HTTP-only cookie (see `AUTH_COOKIE_*`). Clients should simply navigate to `/auth/finish` to let the server decide the final destination. All endpoints return `{ "code": "..." }` on error according to the server logic.
 
 ### `GET /auth/finish`
-Reads `gtc_user_id` from the transient cookie, calls the entitlement RPC, and issues a `302` redirect:
+Reads `gtc_user_id` from the transient cookie, queries `public.subscriptions` in PostgreSQL, and issues a `302` redirect:
 
 - Active subscription (`is_active === true`) → `https://app.gtstor.com/chat/`
-- Missing/expired subscription or RPC failure → `https://pay.gtstor.com/payment.php?user_id=<gtc_user_id>`
+- Missing/expired subscription or query failure → `https://pay.gtstor.com/payment.php?user_id=<gtc_user_id>`
 
 The handler forwards validated `lang` and `next` query parameters to the target.
 
-> **Important:** Entitlement decisions are based exclusively on the PostgREST `subscription_status` RPC. Stripe Customer Portal
-> interactions are only triggered by explicit user actions (for example, `/billing/portal`) and never as part of the post-login
-> flow.
+> **Important:** Entitlement decisions are based exclusively on the data stored in `public.subscriptions` on the GTC1 PostgreSQL
+> cluster. Stripe Customer Portal interactions are only triggered by explicit user actions (for example, `/billing/portal`) and
+> never as part of the post-login flow.
 
 ## systemd unit
 

--- a/srv/gtc-auth/db.js
+++ b/srv/gtc-auth/db.js
@@ -78,7 +78,9 @@ export async function setEmailVerified(userId, email) {
 
 export async function createVerifyToken(userId, email, ttlMinutes = 60) {
   const { rows } = await pool.query(
-    'INSERT INTO public.auth_verification(token,user_id,email,expires_at) VALUES (gen_random_uuid(),$1,$2,now() + ($3 || '' minutes'')::interval) RETURNING token',
+    `INSERT INTO public.auth_verification(token,user_id,email,expires_at)
+     VALUES (gen_random_uuid(),$1,$2,now() + ($3 || ' minutes')::interval)
+     RETURNING token`,
     [userId, email, ttlMinutes]
   );
   return rows[0].token;

--- a/srv/gtc-auth/entitlement.js
+++ b/srv/gtc-auth/entitlement.js
@@ -1,24 +1,42 @@
-import nodeFetch from 'node-fetch';
+import { pool } from './db.js';
 
-const DEFAULT_RPC_URL = process.env.ENTITLEMENT_RPC_URL || 'https://app.gtstor.com/api/rpc/subscription_status';
-const DEFAULT_TIMEOUT_MS = Number.parseInt(process.env.ENTITLEMENT_TIMEOUT_MS ?? '', 10);
-const RPC_TIMEOUT_MS = Number.isFinite(DEFAULT_TIMEOUT_MS) && DEFAULT_TIMEOUT_MS > 0 ? DEFAULT_TIMEOUT_MS : 2500;
-const USER_ID_FIELD = process.env.ENTITLEMENT_RPC_USER_FIELD || 'p_gtc_user_id';
+const ACTIVE_STATUSES = new Set(['active', 'trialing']);
+const SUBSCRIPTION_STATUS_QUERY = `
+  SELECT
+    subscription_id,
+    gtc_user_id,
+    status,
+    plan_code,
+    start_date,
+    end_date,
+    stripe_customer_id,
+    stripe_subscription_id,
+    livemode,
+    is_active,
+    created_at,
+    updated_at
+  FROM public.subscriptions
+  WHERE gtc_user_id = $1
+  ORDER BY
+    COALESCE(
+      is_active,
+      CASE
+        WHEN status IS NULL THEN FALSE
+        WHEN lower(status) IN ('active', 'trialing') THEN
+          CASE
+            WHEN end_date IS NULL THEN TRUE
+            ELSE end_date > now()
+          END
+        ELSE FALSE
+      END
+    ) DESC,
+    end_date DESC NULLS LAST,
+    updated_at DESC NULLS LAST,
+    created_at DESC NULLS LAST
+  LIMIT 1
+`;
 
-const fallbackFetchRef = { current: nodeFetch };
-
-export function setEntitlementFallbackFetch(fetchFn) {
-  if (typeof fetchFn !== 'function') {
-    throw new TypeError('fallback_fetch_must_be_function');
-  }
-  fallbackFetchRef.current = fetchFn;
-}
-
-export function getEntitlementFallbackFetch() {
-  return fallbackFetchRef.current;
-}
-
-function normalizeUserIdForRpc(value) {
+function normalizeUserIdForQuery(value) {
   if (value === undefined || value === null) {
     throw new TypeError('gtc_user_id_required');
   }
@@ -29,62 +47,118 @@ function normalizeUserIdForRpc(value) {
   return numeric;
 }
 
-function resolveFetch(fetchImpl) {
-  if (typeof fetchImpl === 'function') {
-    return fetchImpl;
+function resolveQueryExecutor(queryImpl) {
+  if (typeof queryImpl === 'function') {
+    return queryImpl;
   }
-  if (typeof globalThis.fetch === 'function') {
-    return globalThis.fetch;
+  if (queryImpl && typeof queryImpl.query === 'function') {
+    return queryImpl.query.bind(queryImpl);
   }
-  return fallbackFetchRef.current;
+  if (pool && typeof pool.query === 'function') {
+    return pool.query.bind(pool);
+  }
+  throw new TypeError('subscription_query_unavailable');
 }
 
-export async function fetchSubscriptionStatus(gtcUserId, { fetchImpl } = {}) {
-  if (typeof fetchImpl !== 'function') {
-    fetchImpl = resolveFetch(fetchImpl);
+function coerceBoolean(value) {
+  if (value === true) return true;
+  if (value === false) return false;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', 't', '1', 'yes', 'y'].includes(normalized)) return true;
+    if (['false', 'f', '0', 'no', 'n'].includes(normalized)) return false;
+  }
+  if (typeof value === 'number') {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  return undefined;
+}
+
+function toDate(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.valueOf()) ? null : value;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) {
+    return null;
+  }
+  return parsed;
+}
+
+function toIsoString(value) {
+  const date = toDate(value);
+  return date ? date.toISOString() : null;
+}
+
+function computeIsActive({ explicit, status, endDate }) {
+  const coerced = coerceBoolean(explicit);
+  if (typeof coerced === 'boolean') {
+    return coerced;
   }
 
-  const normalizedId = normalizeUserIdForRpc(gtcUserId);
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS);
-
-  try {
-    const response = await fetchImpl(DEFAULT_RPC_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ [USER_ID_FIELD]: normalizedId }),
-      signal: controller.signal
-    });
-
-    if (!response || typeof response.ok !== 'boolean') {
-      const error = new Error('entitlement_invalid_response');
-      error.cause = response;
-      throw error;
-    }
-
-    if (!response.ok) {
-      const error = new Error('entitlement_request_failed');
-      error.status = response.status;
-      throw error;
-    }
-
-    return response.json();
-  } catch (error) {
-    if (error.name === 'AbortError') {
-      const timeoutError = new Error('entitlement_request_timeout');
-      timeoutError.cause = error;
-      throw timeoutError;
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
+  if (!status) {
+    return false;
   }
+
+  const normalizedStatus = String(status).trim().toLowerCase();
+  if (!ACTIVE_STATUSES.has(normalizedStatus)) {
+    return false;
+  }
+
+  const parsedEndDate = toDate(endDate);
+  if (!parsedEndDate) {
+    return true;
+  }
+
+  return parsedEndDate.getTime() > Date.now();
+}
+
+export async function fetchSubscriptionStatus(gtcUserId, { queryImpl } = {}) {
+  const normalizedId = normalizeUserIdForQuery(gtcUserId);
+  const executeQuery = resolveQueryExecutor(queryImpl);
+
+  const result = await executeQuery(SUBSCRIPTION_STATUS_QUERY, [normalizedId]);
+  const rows = result?.rows ?? [];
+
+  if (rows.length === 0) {
+    return {
+      is_active: false,
+      status: null,
+      end_date: null
+    };
+  }
+
+  const row = rows[0];
+  const status = row.status ?? null;
+  const endDateIso = toIsoString(row.end_date);
+  const startDateIso = toIsoString(row.start_date);
+  const createdAtIso = toIsoString(row.created_at);
+  const updatedAtIso = toIsoString(row.updated_at);
+
+  return {
+    subscription_id: row.subscription_id ?? null,
+    gtc_user_id: row.gtc_user_id ?? normalizedId,
+    status,
+    plan_code: row.plan_code ?? null,
+    start_date: startDateIso,
+    end_date: endDateIso,
+    stripe_customer_id: row.stripe_customer_id ?? null,
+    stripe_subscription_id: row.stripe_subscription_id ?? null,
+    livemode: typeof row.livemode === 'boolean' ? row.livemode : coerceBoolean(row.livemode) ?? null,
+    created_at: createdAtIso,
+    updated_at: updatedAtIso,
+    is_active: computeIsActive({
+      explicit: row.is_active,
+      status,
+      endDate: row.end_date
+    }),
+    source: 'sql'
+  };
 }
 
 export const entitlementConfig = Object.freeze({
-  url: DEFAULT_RPC_URL,
-  timeoutMs: RPC_TIMEOUT_MS,
-  userIdField: USER_ID_FIELD
+  query: SUBSCRIPTION_STATUS_QUERY,
+  activeStatuses: [...ACTIVE_STATUSES]
 });

--- a/srv/gtc-auth/package-lock.json
+++ b/srv/gtc-auth/package-lock.json
@@ -16,7 +16,6 @@
         "express-rate-limit": "^7.1.5",
         "google-auth-library": "^9.14.1",
         "helmet": "^7.1.0",
-        "node-fetch": "^3.3.2",
         "nodemailer": "^6.9.14",
         "pg": "^8.12.0",
         "uuid": "^9.0.1"
@@ -213,15 +212,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -423,29 +413,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -462,18 +429,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -877,44 +832,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nodemailer": {
@@ -1396,15 +1313,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/srv/gtc-auth/package.json
+++ b/srv/gtc-auth/package.json
@@ -17,7 +17,6 @@
     "express-rate-limit": "^7.1.5",
     "google-auth-library": "^9.14.1",
     "helmet": "^7.1.0",
-    "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.14",
     "pg": "^8.12.0",
     "uuid": "^9.0.1"

--- a/srv/gtc-auth/post-auth-redirect.js
+++ b/srv/gtc-auth/post-auth-redirect.js
@@ -55,7 +55,7 @@ function isEntitlementActive(entitlement) {
 
   const endDate = parseEndDate(entitlement.end_date);
   if (!endDate) {
-    return false;
+    return true;
   }
 
   return endDate.getTime() > Date.now();
@@ -148,7 +148,12 @@ export async function determinePostAuthRedirect({
     const entitlement = await fetchEntitlement(normalizedId);
     const isActive = isEntitlementActive(entitlement);
     const location = isActive ? buildChatRedirect(forwarded) : buildPaymentRedirect(normalizedId, forwarded);
-    return { location, isActive, entitlement, rawEntitlement };
+    return {
+      location,
+      isActive,
+      entitlement,
+      rawEntitlement: entitlement
+    };
   } catch (error) {
     const fallback = buildPaymentRedirect(normalizedId, forwarded);
     return { location: fallback, error };

--- a/srv/gtc-auth/tests/entitlement.test.mjs
+++ b/srv/gtc-auth/tests/entitlement.test.mjs
@@ -1,88 +1,108 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  fetchSubscriptionStatus,
-  setEntitlementFallbackFetch,
-  getEntitlementFallbackFetch
-} from '../entitlement.js';
+import { fetchSubscriptionStatus, entitlementConfig } from '../entitlement.js';
 
-const ORIGINAL_FALLBACK = getEntitlementFallbackFetch();
+function futureDate(days = 1) {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+}
 
-test.after(() => {
-  setEntitlementFallbackFetch(ORIGINAL_FALLBACK);
-});
+function pastDate(days = 1) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
 
-test('fetchSubscriptionStatus posts normalized numeric id to the RPC', async () => {
+test('fetchSubscriptionStatus queries Postgres with normalized id', async () => {
   let captured;
-  const response = {
-    ok: true,
-    json: async () => ({ is_active: true })
-  };
-  const fakeFetch = async (url, options) => {
-    captured = { url, options };
-    return response;
+  const fakeQuery = async (sql, params) => {
+    captured = { sql, params };
+    return {
+      rows: [
+        {
+          subscription_id: 42,
+          gtc_user_id: 3001,
+          status: 'active',
+          end_date: futureDate(),
+          plan_code: 'pro',
+          stripe_customer_id: 'cus_123',
+          stripe_subscription_id: 'sub_123',
+          created_at: futureDate(-1),
+          updated_at: futureDate()
+        }
+      ]
+    };
   };
 
-  const result = await fetchSubscriptionStatus(' 3001 ', { fetchImpl: fakeFetch });
+  const result = await fetchSubscriptionStatus(' 3001 ', { queryImpl: fakeQuery });
 
-  assert.deepEqual(result, { is_active: true });
-  assert.equal(captured.url, 'https://app.gtstor.com/api/rpc/subscription_status');
-  assert.equal(captured.options.method, 'POST');
-  assert.equal(captured.options.headers['Content-Type'], 'application/json');
-  assert.deepEqual(JSON.parse(captured.options.body), { p_gtc_user_id: 3001 });
-  assert.equal(typeof captured.options.signal, 'object');
-  assert.equal(typeof captured.options.signal?.aborted, 'boolean');
+  assert.ok(captured.sql.includes('FROM public.subscriptions'));
+  assert.deepEqual(captured.params, [3001]);
+  assert.equal(result.status, 'active');
+  assert.equal(result.plan_code, 'pro');
+  assert.equal(result.is_active, true);
+  assert.equal(result.source, 'sql');
+  assert.match(result.end_date, /Z$/);
 });
 
-test('non-ok RPC responses bubble up with entitlement_request_failed', async () => {
-  await assert.rejects(
-    () =>
-      fetchSubscriptionStatus(3001, {
-        fetchImpl: async () => ({ ok: false, status: 503 })
-      }),
-    (error) => error.message === 'entitlement_request_failed' && error.status === 503
+test('missing subscription rows default to inactive state', async () => {
+  const result = await fetchSubscriptionStatus(3002, {
+    queryImpl: async () => ({ rows: [] })
+  });
+
+  assert.equal(result.is_active, false);
+  assert.equal(result.status, null);
+  assert.equal(result.end_date, null);
+});
+
+test('expired subscriptions are treated as inactive', async () => {
+  const result = await fetchSubscriptionStatus('3003', {
+    queryImpl: async () => ({
+      rows: [
+        {
+          status: 'trialing',
+          end_date: pastDate(),
+          updated_at: pastDate()
+        }
+      ]
+    })
+  });
+
+  assert.equal(result.is_active, false);
+});
+
+test('active status without end date is considered active', async () => {
+  const result = await fetchSubscriptionStatus(3004, {
+    queryImpl: async () => ({
+      rows: [
+        {
+          status: 'active',
+          end_date: null
+        }
+      ]
+    })
+  });
+
+  assert.equal(result.is_active, true);
+});
+
+test('boolean flags from SQL override computed status', async () => {
+  const result = await fetchSubscriptionStatus(3005, {
+    queryImpl: async () => ({
+      rows: [
+        {
+          status: 'canceled',
+          end_date: futureDate(),
+          is_active: true
+        }
+      ]
+    })
+  });
+
+  assert.equal(result.is_active, true);
+});
+
+test('subscription query prioritizes active rows ahead of stale history', () => {
+  assert.match(entitlementConfig.query, /COALESCE\s*\(\s*is_active/);
+  assert.match(
+    entitlementConfig.query,
+    /COALESCE[\s\S]+end_date DESC NULLS LAST,\s*updated_at DESC NULLS LAST,\s*created_at DESC NULLS LAST/s
   );
-});
-
-test('default global fetch is used when no override provided', async () => {
-  const originalFetch = globalThis.fetch;
-  let invoked = false;
-  globalThis.fetch = async () => {
-    invoked = true;
-    return { ok: true, json: async () => ({ status: 'active' }) };
-  };
-
-  try {
-    const result = await fetchSubscriptionStatus(3001);
-    assert.deepEqual(result, { status: 'active' });
-    assert.equal(invoked, true);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test('fallback fetch implementation is used when global fetch is absent', async () => {
-  const originalFetch = globalThis.fetch;
-  const originalFallback = getEntitlementFallbackFetch();
-  let invoked = false;
-  const fakeFallback = async () => {
-    invoked = true;
-    return { ok: true, json: async () => ({ is_active: 't' }) };
-  };
-
-  try {
-    globalThis.fetch = undefined;
-    setEntitlementFallbackFetch(fakeFallback);
-
-    const result = await fetchSubscriptionStatus('3001');
-    assert.equal(invoked, true);
-    assert.deepEqual(result, { is_active: 't' });
-  } finally {
-    globalThis.fetch = originalFetch;
-    setEntitlementFallbackFetch(originalFallback);
-  }
-});
-
-test('setEntitlementFallbackFetch enforces function contract', () => {
-  assert.throws(() => setEntitlementFallbackFetch(null), /fallback_fetch_must_be_function/);
 });

--- a/srv/gtc-auth/tests/post-auth-redirect.test.mjs
+++ b/srv/gtc-auth/tests/post-auth-redirect.test.mjs
@@ -8,7 +8,7 @@ import {
 
 const noopFetch = async () => ({ is_active: true });
 
-test('string flag from RPC still routes active subscribers to chat', async () => {
+test('string flag from SQL still routes active subscribers to chat', async () => {
   const decision = await determinePostAuthRedirect({
     gtcUserId: '3001',
     fetchEntitlement: async () => ({ is_active: 't' })
@@ -17,11 +17,30 @@ test('string flag from RPC still routes active subscribers to chat', async () =>
   assert.equal(decision.isActive, true);
 });
 
+test('rawEntitlement mirrors the subscription payload for downstream logging', async () => {
+  const entitlement = { is_active: true, status: 'active' };
+  const decision = await determinePostAuthRedirect({
+    gtcUserId: '3001',
+    fetchEntitlement: async () => entitlement
+  });
+  assert.equal(decision.entitlement, entitlement);
+  assert.equal(decision.rawEntitlement, entitlement);
+});
+
 test('status + future end_date imply activity when boolean flag missing', async () => {
   const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
   const decision = await determinePostAuthRedirect({
     gtcUserId: '3001',
     fetchEntitlement: async () => ({ status: 'active', end_date: future })
+  });
+  assert.equal(decision.location, 'https://app.gtstor.com/chat/');
+  assert.equal(decision.isActive, true);
+});
+
+test('status without end_date still routes active members to chat', async () => {
+  const decision = await determinePostAuthRedirect({
+    gtcUserId: '3001',
+    fetchEntitlement: async () => ({ status: 'active', end_date: null })
   });
   assert.equal(decision.location, 'https://app.gtstor.com/chat/');
   assert.equal(decision.isActive, true);
@@ -61,7 +80,7 @@ test('inactive users are routed to the payment portal with their id', async () =
   assert.equal(url.searchParams.get('next'), '/chat/history');
 });
 
-test('RPC failures fall back to the payment portal and surface the error', async () => {
+test('subscription lookups that throw fall back to the payment portal', async () => {
   const rpcError = new Error('network down');
   const decision = await determinePostAuthRedirect({
     gtcUserId: '3001',


### PR DESCRIPTION
## Summary
- adjust the subscription lookup to surface is_active and sort by a computed active flag so ongoing plans are returned ahead of stale rows
- treat active subscriptions without an end date as valid during post-auth redirect and add coverage for the scenario
- extend SQL query documentation tests to ensure the prioritization logic stays in place

## Testing
- npm test --prefix srv/gtc-auth

------
https://chatgpt.com/codex/tasks/task_e_68f143c42ec4832ab3855d4e685f8b96